### PR TITLE
Fix unsupported source option compilation error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
 
     <properties>
         <java.version>11</java.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <spring-boot-dependencies.version>2.7.8</spring-boot-dependencies.version>
         <start-class>uk.gov.companieshouse.documentsigningapi.DocumentSigningApiApplication</start-class>
 


### PR DESCRIPTION
Re-add `maven.compiler.source` and `maven.compiler.target` to fix unsupported source option compilation error.