### PR TITLE
DCAC-68: Try assigning variable before counting down latch

### DIFF
--- a/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/integration/ItemGroupControllerCreateItemGroupIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/integration/ItemGroupControllerCreateItemGroupIntegrationTest.java
@@ -343,8 +343,8 @@ class ItemGroupControllerCreateItemGroupIntegrationTest {
     @KafkaListener(topics = ITEM_ORDERED_CERTIFIED_COPY_TOPIC, groupId = "test-group")
     public void receiveMessage(final @Payload ItemOrderedCertifiedCopy message) {
         LOGGER.info("Received message: " + message);
-        messageReceivedLatch.countDown();
         messageReceived = message;
+        messageReceivedLatch.countDown();
     }
 
     private void verifyExpectedMessageIsReceived() throws InterruptedException {


### PR DESCRIPTION
* I speculate that counting down the latch before the variable is assigned with the expected value may explain why the test `ItemGroupControllerCreateItemGroupIntegrationTest.createItemGroupSuccessful201Created` has failed intermittently in the last few test runs on Concourse?