### PR TITLE
DCAC-68: Make topic name configurable as required for Kafka 3 set up

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/environment/EnvironmentVariablesChecker.java
+++ b/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/environment/EnvironmentVariablesChecker.java
@@ -13,7 +13,8 @@ public class EnvironmentVariablesChecker {
 
     public enum RequiredEnvironmentVariables {
         MONGODB_URL("MONGODB_URL"),
-        BOOTSTRAP_SERVER_URL("BOOTSTRAP_SERVER_URL");
+        BOOTSTRAP_SERVER_URL("BOOTSTRAP_SERVER_URL"),
+        ITEM_ORDERED_CERTIFIED_COPY_TOPIC("ITEM_ORDERED_CERTIFIED_COPY_TOPIC");
 
         private final String name;
 

--- a/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/util/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/util/Constants.java
@@ -8,6 +8,4 @@ public class Constants {
     public static final String REQUEST_ID_HEADER_NAME = "X-Request-ID";
     public static final String JSON_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS";
 
-    public static final String ITEM_ORDERED_CERTIFIED_COPY_TOPIC = "item-ordered-certified-copy";
-
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,4 @@ spring.main.allow-bean-definition-overriding=true
 spring.data.mongodb.field-naming-strategy=org.springframework.data.mapping.model.SnakeCaseFieldNamingStrategy
 
 spring.kafka.bootstrap-servers=${BOOTSTRAP_SERVER_URL}
+kafka.topics.item-ordered-certified-copy=${ITEM_ORDERED_CERTIFIED_COPY_TOPIC}

--- a/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/environment/EnvironmentVariablesCheckerTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/environment/EnvironmentVariablesCheckerTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static uk.gov.companieshouse.itemgroupworkflowapi.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.BOOTSTRAP_SERVER_URL;
+import static uk.gov.companieshouse.itemgroupworkflowapi.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.ITEM_ORDERED_CERTIFIED_COPY_TOPIC;
 import static uk.gov.companieshouse.itemgroupworkflowapi.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.MONGODB_URL;
 
 @SpringBootTest
@@ -53,6 +54,12 @@ class EnvironmentVariablesCheckerTest {
     @Test
     void checkEnvironmentVariablesAllPresentReturnsFalseIfBootstrapServerUrlMissing() {
         populateAllVariablesExceptOneAndAssertSomethingMissing(BOOTSTRAP_SERVER_URL);
+    }
+
+    @DisplayName("returns false if ITEM_ORDERED_CERTIFIED_COPY_TOPIC is missing")
+    @Test
+    void checkEnvironmentVariablesAllPresentReturnsFalseIfItemOrderedCertifiedCopyTopicMissing() {
+        populateAllVariablesExceptOneAndAssertSomethingMissing(ITEM_ORDERED_CERTIFIED_COPY_TOPIC);
     }
 
     private void populateAllVariablesExceptOneAndAssertSomethingMissing(

--- a/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/integration/ItemGroupControllerCreateItemGroupIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/integration/ItemGroupControllerCreateItemGroupIntegrationTest.java
@@ -58,7 +58,6 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.companieshouse.itemgroupworkflowapi.util.Constants.ITEM_ORDERED_CERTIFIED_COPY_TOPIC;
 import static uk.gov.companieshouse.itemgroupworkflowapi.util.TestConstants.CERTIFIED_COPY_ITEM_OPTIONS;
 import static uk.gov.companieshouse.itemgroupworkflowapi.util.TestConstants.ERIC_AUTHORISED_ROLES_HEADER_NAME;
 import static uk.gov.companieshouse.itemgroupworkflowapi.util.TestConstants.ERIC_AUTHORISED_ROLES_HEADER_VALUE;
@@ -66,6 +65,7 @@ import static uk.gov.companieshouse.itemgroupworkflowapi.util.TestConstants.ERIC
 import static uk.gov.companieshouse.itemgroupworkflowapi.util.TestConstants.ERIC_IDENTITY_HEADER_VALUE;
 import static uk.gov.companieshouse.itemgroupworkflowapi.util.TestConstants.ERIC_IDENTITY_TYPE_HEADER_NAME;
 import static uk.gov.companieshouse.itemgroupworkflowapi.util.TestConstants.ERIC_IDENTITY_TYPE_HEADER_VALUE;
+import static uk.gov.companieshouse.itemgroupworkflowapi.util.TestConstants.ITEM_ORDERED_CERTIFIED_COPY_TOPIC;
 
 /**
  * Integration tests the {@link uk.gov.companieshouse.itemgroupworkflowapi.controller.ItemGroupController} class's

--- a/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/integration/ItemOrderedCertifiedCopyInTiltProducer.java
+++ b/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/integration/ItemOrderedCertifiedCopyInTiltProducer.java
@@ -7,6 +7,7 @@ import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.Rule;
@@ -24,7 +25,6 @@ import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import uk.gov.companieshouse.itemorderedcertifiedcopy.ItemOrderedCertifiedCopy;
-import org.apache.kafka.common.errors.SerializationException;
 import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
 
 import java.io.ByteArrayOutputStream;
@@ -32,8 +32,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static uk.gov.companieshouse.itemgroupworkflowapi.util.Constants.ITEM_ORDERED_CERTIFIED_COPY_TOPIC;
 import static uk.gov.companieshouse.itemgroupworkflowapi.util.TestConstants.CERTIFIED_COPY;
+import static uk.gov.companieshouse.itemgroupworkflowapi.util.TestConstants.ITEM_ORDERED_CERTIFIED_COPY_TOPIC;
 import static uk.gov.companieshouse.itemgroupworkflowapi.util.TestConstants.SAME_PARTITION_KEY;
 
 /**

--- a/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/service/KafkaProducerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/service/KafkaProducerServiceTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.itemgroupworkflowapi.model.ItemKind.ITEM_CERTIFICATE;
 import static uk.gov.companieshouse.itemgroupworkflowapi.model.ItemKind.ITEM_CERTIFIED_COPY;
 import static uk.gov.companieshouse.itemgroupworkflowapi.model.ItemKind.ITEM_MISSING_IMAGE_DELIVERY;
-import static uk.gov.companieshouse.itemgroupworkflowapi.util.Constants.ITEM_ORDERED_CERTIFIED_COPY_TOPIC;
+import static uk.gov.companieshouse.itemgroupworkflowapi.util.TestConstants.ITEM_ORDERED_CERTIFIED_COPY_TOPIC;
 
 /**
  * Unit tests the {@link KafkaProducerService} class.
@@ -59,10 +59,13 @@ class KafkaProducerServiceTest {
     @Mock
     private ItemOrderedCertifiedCopy message;
 
+
+
     @BeforeEach
     void setUp() {
         when(loggingUtils.getLogger()).thenReturn(logger);
-        service = new KafkaProducerService(kafkaTemplate, loggingUtils, certifiedCopyFactory);
+        service = new KafkaProducerService(
+                kafkaTemplate, loggingUtils, certifiedCopyFactory, ITEM_ORDERED_CERTIFIED_COPY_TOPIC);
         service.afterPropertiesSet();
     }
 

--- a/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/util/TestConstants.java
+++ b/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/util/TestConstants.java
@@ -51,4 +51,7 @@ public class TestConstants {
             "delivery_method", "collection",
             "delivery_timescale", "standard"
         );
+
+    public static final String ITEM_ORDERED_CERTIFIED_COPY_TOPIC = "item-ordered-certified-copy";
+
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -20,3 +20,4 @@ spring.mongodb.embedded.version=4.0.2
 spring.data.mongodb.field-naming-strategy=org.springframework.data.mapping.model.SnakeCaseFieldNamingStrategy
 
 spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}
+kafka.topics.item-ordered-certified-copy=item-ordered-certified-copy


### PR DESCRIPTION
* For the Kafka 3 set up, we have a different topic name for each environment, consisting of `<env name>-<topic name>`. 
* These changes make the topic name used by the app configurable via an environment variable, as appropriate for the environment it may be deployed to.