### PR TITLE
DCAC-285: Prevent 409 Conflict response for item groups sharing the same order no

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/controller/ItemGroupController.java
+++ b/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/controller/ItemGroupController.java
@@ -1,6 +1,17 @@
 package uk.gov.companieshouse.itemgroupworkflowapi.controller;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static uk.gov.companieshouse.itemgroupworkflowapi.util.Constants.REQUEST_ID_HEADER_NAME;
+import static uk.gov.companieshouse.itemgroupworkflowapi.util.ItemGroupDataUtils.getItemIds;
+import static uk.gov.companieshouse.itemgroupworkflowapi.util.PatchMediaType.APPLICATION_MERGE_PATCH_VALUE;
+
 import jakarta.json.JsonMergePatch;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -20,18 +31,6 @@ import uk.gov.companieshouse.itemgroupworkflowapi.validation.ItemGroupsValidator
 import uk.gov.companieshouse.itemgroupworkflowapi.validation.PatchItemRequestValidator;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.util.DataMap;
-
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.CONFLICT;
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static uk.gov.companieshouse.itemgroupworkflowapi.util.Constants.REQUEST_ID_HEADER_NAME;
-import static uk.gov.companieshouse.itemgroupworkflowapi.util.ItemGroupDataUtils.getItemIds;
-import static uk.gov.companieshouse.itemgroupworkflowapi.util.PatchMediaType.APPLICATION_MERGE_PATCH_VALUE;
 
 
 @RestController

--- a/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/controller/ItemGroupController.java
+++ b/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/controller/ItemGroupController.java
@@ -30,6 +30,7 @@ import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static uk.gov.companieshouse.itemgroupworkflowapi.util.Constants.REQUEST_ID_HEADER_NAME;
+import static uk.gov.companieshouse.itemgroupworkflowapi.util.ItemGroupDataUtils.getItemIds;
 import static uk.gov.companieshouse.itemgroupworkflowapi.util.PatchMediaType.APPLICATION_MERGE_PATCH_VALUE;
 
 
@@ -173,12 +174,8 @@ public class ItemGroupController {
             .requestId(xRequestId)
             .orderId(itemGroupData.getOrderNumber())
             .build();
+        log().error(CREATE_ITEM_GROUP_ALREADY_EXISTS_PREFIX + getItemIds(itemGroupData), dataMap.getLogMap());
 
-        final List<String> newItemGroupItemIds = itemGroupData.getItems().stream()
-            .map(Item::getId)
-            .collect(Collectors.toList());
-
-        log().error(CREATE_ITEM_GROUP_ALREADY_EXISTS_PREFIX + newItemGroupItemIds, dataMap.getLogMap());
         return ResponseEntity.status(CONFLICT).body(itemGroupData);
     }
 

--- a/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/repository/ItemGroupsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/repository/ItemGroupsRepository.java
@@ -1,10 +1,13 @@
 package uk.gov.companieshouse.itemgroupworkflowapi.repository;
 
+import java.util.List;
+import org.springframework.data.mongodb.repository.ExistsQuery;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.companieshouse.itemgroupworkflowapi.model.ItemGroup;
 
 @Repository
 public interface ItemGroupsRepository extends MongoRepository<ItemGroup, String> {
-    boolean existsItemGroupByDataOrderNumber(String orderNumber);
+    @ExistsQuery("{ 'data.items.id': { $exists: true, $in: ?0 } }")
+    boolean existItemGroupsWithSameItems(List<String> itemIds);
 }

--- a/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/service/ItemGroupsService.java
+++ b/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/service/ItemGroupsService.java
@@ -3,12 +3,12 @@ package uk.gov.companieshouse.itemgroupworkflowapi.service;
 import static java.time.LocalDateTime.now;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
+import static uk.gov.companieshouse.itemgroupworkflowapi.util.ItemGroupDataUtils.getItemIds;
 
 import com.mongodb.MongoException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.itemgroupworkflowapi.exception.ItemNotFoundException;
 import uk.gov.companieshouse.itemgroupworkflowapi.exception.MongoOperationException;
@@ -46,9 +46,7 @@ public class ItemGroupsService {
 
     public boolean existingItemGroupsContainSameItems(ItemGroupData itemGroupData){
         boolean existingItemGroupsContainSameItems;
-        final List<String> newItemGroupItemIds = itemGroupData.getItems().stream()
-            .map(Item::getId)
-            .collect(Collectors.toList());
+        final List<String> newItemGroupItemIds = getItemIds(itemGroupData);
         try {
             existingItemGroupsContainSameItems =
                 itemGroupsRepository.existItemGroupsWithSameItems(newItemGroupItemIds);

--- a/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/service/ItemGroupsService.java
+++ b/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/service/ItemGroupsService.java
@@ -1,6 +1,14 @@
 package uk.gov.companieshouse.itemgroupworkflowapi.service;
 
+import static java.time.LocalDateTime.now;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+
 import com.mongodb.MongoException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.itemgroupworkflowapi.exception.ItemNotFoundException;
 import uk.gov.companieshouse.itemgroupworkflowapi.exception.MongoOperationException;
@@ -11,18 +19,13 @@ import uk.gov.companieshouse.itemgroupworkflowapi.model.ItemGroupData;
 import uk.gov.companieshouse.itemgroupworkflowapi.repository.ItemGroupsRepository;
 import uk.gov.companieshouse.logging.util.DataMap;
 
-import java.time.LocalDateTime;
-import java.util.Map;
-
-import static java.time.LocalDateTime.now;
-import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toList;
-
 @Service
 public class ItemGroupsService {
 
-    public static String MONGO_EXISTS_EXCEPTION_MESSAGE = "Mongo EXISTS operation failed for item group order number : ";
-    public static String MONGO_SAVE_EXCEPTION_MESSAGE = "Mongo SAVE operation failed for item group order number : ";
+    public static final String MONGO_EXISTS_EXCEPTION_MESSAGE =
+        "Mongo EXISTS operation failed for item group with items : ";
+    public static final String MONGO_SAVE_EXCEPTION_MESSAGE =
+        "Mongo SAVE operation failed for item group order number : ";
     private final LoggingUtils logger;
     private final ItemGroupsRepository itemGroupsRepository;
     private final LinksGeneratorService linksGenerator;
@@ -41,18 +44,22 @@ public class ItemGroupsService {
         this.idGenerator = idGenerator;
     }
 
-    public boolean doesItemGroupExist(ItemGroupData itemGroupData){
-        boolean itemExists;
+    public boolean existingItemGroupsContainSameItems(ItemGroupData itemGroupData){
+        boolean existingItemGroupsContainSameItems;
+        final List<String> newItemGroupItemIds = itemGroupData.getItems().stream()
+            .map(Item::getId)
+            .collect(Collectors.toList());
         try {
-            itemExists = itemGroupsRepository.existsItemGroupByDataOrderNumber(itemGroupData.getOrderNumber());
+            existingItemGroupsContainSameItems =
+                itemGroupsRepository.existItemGroupsWithSameItems(newItemGroupItemIds);
         } catch (MongoException mex) {
-            throw new MongoOperationException(MONGO_EXISTS_EXCEPTION_MESSAGE + itemGroupData.getOrderNumber(), mex);
+            throw new MongoOperationException(MONGO_EXISTS_EXCEPTION_MESSAGE + newItemGroupItemIds, mex);
         }
 
-        return itemExists;
+        return existingItemGroupsContainSameItems;
     }
     public ItemGroupData createItemGroup(ItemGroupData itemGroupData) {
-        final ItemGroup itemGroup = new ItemGroup();
+        final var itemGroup = new ItemGroup();
 
         String itemGroupId = idGenerator.generateId();
         itemGroup.setId(itemGroupId);
@@ -102,7 +109,7 @@ public class ItemGroupsService {
 
 
     private void setCreationTimeStamp(final ItemGroup itemGroup) {
-        final LocalDateTime now = LocalDateTime.now();
+        final var now = LocalDateTime.now();
         itemGroup.setCreatedAt(now);
         itemGroup.setUpdatedAt(now);
     }

--- a/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/util/ItemGroupDataUtils.java
+++ b/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/util/ItemGroupDataUtils.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.itemgroupworkflowapi.util;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import uk.gov.companieshouse.itemgroupworkflowapi.model.Item;
+import uk.gov.companieshouse.itemgroupworkflowapi.model.ItemGroupData;
+
+public class ItemGroupDataUtils {
+
+    private ItemGroupDataUtils() {}
+
+    public static List<String> getItemIds(final ItemGroupData itemGroup) {
+        return itemGroup.getItems().stream()
+            .map(Item::getId)
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/controller/ItemGroupControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/controller/ItemGroupControllerTest.java
@@ -62,7 +62,7 @@ class ItemGroupControllerTest {
 
     @Test
     @DisplayName("create item group succeeds return 201 CREATED")
-    void createItemGroupReturnCreated201()  throws Exception {
+    void createItemGroupReturnCreated201() {
         final ItemGroupData itemGroupData = fairWeatherItemGroupsDto();
         ItemGroup itemGroup = new ItemGroup();
         itemGroup.setData(itemGroupData);
@@ -106,7 +106,7 @@ class ItemGroupControllerTest {
 
     @Test
     @DisplayName("validation fails return 400 BAD_REQUEST")
-    void validationFailsReturnBadRequest400()  throws Exception {
+    void validationFailsReturnBadRequest400() {
         final ItemGroupData itemGroupData = invalidItemGroupsDtoMissingAllValidationCriteria();
         ItemGroup itemGroup = new ItemGroup();
         itemGroup.setData(itemGroupData);
@@ -126,12 +126,12 @@ class ItemGroupControllerTest {
 
     @Test
     @DisplayName("item group already exists return 409 CONFLICT")
-    void itemGroupAlreadyExistsReturnConflict409()  throws Exception {
+    void itemGroupAlreadyExistsReturnConflict409() {
         final ItemGroupData itemGroupData = fairWeatherItemGroupsDto();
         ItemGroup itemGroup = new ItemGroup();
         itemGroup.setData(itemGroupData);
 
-        when(itemGroupsService.doesItemGroupExist(itemGroupData)).thenReturn(true);
+        when(itemGroupsService.existingItemGroupsContainSameItems(itemGroupData)).thenReturn(true);
         when(loggingUtils.getLogger()).thenReturn(logger);
 
         final ResponseEntity<Object> response = controller.createItemGroup(X_REQUEST_ID, itemGroupData);
@@ -145,7 +145,7 @@ class ItemGroupControllerTest {
 
     @Test
     @DisplayName("Mongo EXISTS operation return 500 INTERNAL_SERVER_ERROR")
-    void mongoExistsReturnInternalServerError500()  throws Exception {
+    void mongoExistsReturnInternalServerError500() {
         final ItemGroupData itemGroupData = fairWeatherItemGroupsDto();
         ItemGroup itemGroup = new ItemGroup();
         itemGroup.setData(itemGroupData);
@@ -155,7 +155,7 @@ class ItemGroupControllerTest {
         final MongoOperationException moe = new MongoOperationException(
                 MONGO_EXISTS_EXCEPTION_MESSAGE + itemGroupData.getOrderNumber(),
                 new MongoException(""));
-        when(itemGroupsService.doesItemGroupExist(itemGroupData)).thenThrow(moe);
+        when(itemGroupsService.existingItemGroupsContainSameItems(itemGroupData)).thenThrow(moe);
 
         when(loggingUtils.getLogger()).thenReturn(logger);
         //
@@ -172,7 +172,7 @@ class ItemGroupControllerTest {
 
     @Test
     @DisplayName("Mongo SAVE operation return 500 INTERNAL_SERVER_ERROR")
-    void mongoSaveReturnInternalServerError500()  throws Exception {
+    void mongoSaveReturnInternalServerError500() {
         final ItemGroupData itemGroupData = fairWeatherItemGroupsDto();
         ItemGroup itemGroup = new ItemGroup();
         itemGroup.setData(itemGroupData);


### PR DESCRIPTION
* Change the logic to check for the existence of any previously persisted item groups sharing any of the items (item IDs in fact) present on the item group about to be created.
* The `409 Conflict` response should now arise only where the item group about to be created shares any item ID(s) with any of the item groups that have previously been created.