### PR TITLE
DCAC-295: Do not propagate non-satisfied status updates for item ready email

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/controller/ItemGroupController.java
+++ b/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/controller/ItemGroupController.java
@@ -145,7 +145,7 @@ public class ItemGroupController {
 
         var itemGroup = itemGroupsService.findGroup(itemGroupId, itemId);
         itemGroupProcessedProducerService.sendMessage(patchedItem, itemGroup);
-        itemStatusPropagator.propagateItemStatusUpdate(patchedItem, itemGroup);
+        itemStatusPropagator.propagateItemSatisfiedStatusUpdate(patchedItem, itemGroup);
 
         return ResponseEntity.ok().body(patchedItem);
     }

--- a/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/service/ItemStatusPropagationService.java
+++ b/src/main/java/uk/gov/companieshouse/itemgroupworkflowapi/service/ItemStatusPropagationService.java
@@ -57,9 +57,9 @@ public class ItemStatusPropagationService {
         final var status = updatedItem.getStatus();
 
         if (!status.equals(SATISFIED)) {
-            logger.info("Item status update propagation SUPPRESSED for order number "
-                    + orderNumber + ", group item " + groupItem + ", because the updated status `" +
-                    status + "` is not `" + SATISFIED + "`.",
+            logger.info(getPropagationLogMessage("SUPPRESSED", orderNumber, groupItem,
+                    ", because the updated status `" +
+                        status + "` is not `" + SATISFIED + "`."),
                 getLogMap(orderNumber, itemGroup.getId(), updatedItem.getId()));
             return;
         }
@@ -80,14 +80,12 @@ public class ItemStatusPropagationService {
                 HttpMethod.POST,
                 httpEntity,
                 HttpMessage.class);
-            logger.info("Item status update propagation successful for order number "
-                    + orderNumber + ", group item " + groupItem + ".",
+            logger.info(getPropagationLogMessage("successful", orderNumber, groupItem, "."),
                 getLogMap(orderNumber, itemGroup.getId(), updatedItem.getId()));
         } catch (RestClientException rce) {
-            final String error = "Item status update propagation FAILED for order number "
-                + orderNumber + ", group item " + groupItem
-                + ", caught RestClientException with message "
-                + rce.getMessage() + ".";
+            final String error = getPropagationLogMessage("FAILED", orderNumber, groupItem,
+                ", caught RestClientException with message "
+                    + rce.getMessage() + ".");
             logger.error(error,
                 getLogMap(orderNumber, itemGroup.getId(), updatedItem.getId(), rce.getMessage()));
             throw new ItemStatusUpdatePropagationException(error);
@@ -96,6 +94,12 @@ public class ItemStatusPropagationService {
 
     private String getGroupItem(final ItemGroup group, final Item item) {
         return "/item-groups/" + group.getId() + "/items/" + item.getId();
+    }
+
+    private String getPropagationLogMessage(final String outcomeOrAction,
+        final String orderNumber, final String groupItem, final String suffix) {
+        return "Item status update propagation " + outcomeOrAction + " for order number "
+            + orderNumber + ", group item " + groupItem + suffix;
     }
 
     private Map<String, Object> getLogMap(

--- a/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/service/ItemStatusPropagationServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/itemgroupworkflowapi/service/ItemStatusPropagationServiceTest.java
@@ -1,0 +1,91 @@
+package uk.gov.companieshouse.itemgroupworkflowapi.service;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.itemgroupworkflowapi.validation.Status.SATISFIED;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMessage;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.companieshouse.itemgroupworkflowapi.model.Item;
+import uk.gov.companieshouse.itemgroupworkflowapi.model.ItemGroup;
+import uk.gov.companieshouse.itemgroupworkflowapi.model.ItemGroupData;
+import uk.gov.companieshouse.itemgroupworkflowapi.validation.Status;
+import uk.gov.companieshouse.logging.Logger;
+
+/**
+ * Unit tests the {@link ItemStatusPropagationService} class.
+ */
+@ExtendWith(MockitoExtension.class)
+class ItemStatusPropagationServiceTest {
+
+    @InjectMocks
+    private ItemStatusPropagationService itemStatusPropagationService;
+
+    @Mock
+    private Item updatedItem;
+
+    @Mock
+    private ItemGroup itemGroup;
+
+    @Mock
+    private ItemGroupData data;
+
+    @Mock
+    private Logger logger;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Test
+    @DisplayName("SATISFIED status update is propagated on")
+    void satisfiedStatusIsPropagated() {
+
+        // Given
+        when(itemGroup.getData()).thenReturn(data);
+        when(updatedItem.getStatus()).thenReturn(Status.SATISFIED.toString());
+
+        // When
+        itemStatusPropagationService.propagateItemSatisfiedStatusUpdate(updatedItem, itemGroup);
+
+        // Then
+        verify(restTemplate).exchange(anyString(), eq(HttpMethod.POST),
+            any(HttpEntity.class),
+            eq(HttpMessage.class));
+    }
+
+    @Test
+    @DisplayName("non-SATISFIED status updates are not propagated")
+    void nonSatisfiedStatusesAreNotPropagated() {
+        Arrays.stream(Status.values())
+            .filter(status -> status != SATISFIED)
+            .forEach(this::nonSatisfiedStatusIsNotPropagated);
+    }
+
+    private void nonSatisfiedStatusIsNotPropagated(final Status nonSatisfiedStatus) {
+
+        // Given
+        when(itemGroup.getData()).thenReturn(data);
+        when(updatedItem.getStatus()).thenReturn(nonSatisfiedStatus.toString());
+
+        // When
+        itemStatusPropagationService.propagateItemSatisfiedStatusUpdate(updatedItem, itemGroup);
+
+        // Then
+        verify(restTemplate, never()).exchange(anyString(), eq(HttpMethod.POST),
+            any(HttpEntity.class),
+            eq(HttpMessage.class));
+    }
+}


### PR DESCRIPTION
* Item ready emails should not be sent for any status update other than `satisfied`.
* Nor should unnecessary traffic arise as a result of propagating a non-`satisfied` item status to be suppressed further down the chain of communication.
* Hence, tweak `item-group-workflow-api` logic to filter out such unnecessary traffic at source.