### PR TITLE
JU-777 adding ecs info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,31 @@ In order to build `item-group-workflow-api` locally you will need the following:
 | *`/item-groups/{item group ID}/items/{item ID}`* | PATCH  | Updates the status of the item within the group.                    |
 | *`/item-group-workflow-api/healthcheck`*         | GET    | Returns HTTP OK (`200`) to indicate a healthy application instance. |
 
+## Terraform ECS
+
+### What does this code do?
+
+The code present in this repository is used to define and deploy a dockerised container in AWS ECS.
+This is done by calling a [module](https://github.com/companieshouse/terraform-modules/tree/main/aws/ecs) from terraform-modules. Application specific attributes are injected and the service is then deployed using Terraform via the CICD platform 'Concourse'.
+
+
+Application specific attributes | Value                                | Description
+:---------|:-----------------------------------------------------------------------------|:-----------
+**ECS Cluster**        |order-service                                     | ECS cluster (stack) the service belongs to
+**Load balancer**      |{env}-chs-internalapi                                            | The load balancer that sits in front of the service
+**Concourse pipeline**     |[Pipeline link](https://ci-platform.companieshouse.gov.uk/teams/team-development/pipelines/item-group-workflow-api) <br> [Pipeline code](https://github.com/companieshouse/ci-pipelines/blob/master/pipelines/ssplatform/team-development/item-group-workflow-api)                                  | Concourse pipeline link in shared services
+
+
+### Contributing
+- Please refer to the [ECS Development and Infrastructure Documentation](https://companieshouse.atlassian.net/wiki/spaces/DEVOPS/pages/4390649858/Copy+of+ECS+Development+and+Infrastructure+Documentation+Updated) for detailed information on the infrastructure being deployed.
+
+### Testing
+- Ensure the terraform runner local plan executes without issues. For information on terraform runners please see the [Terraform Runner Quickstart guide](https://companieshouse.atlassian.net/wiki/spaces/DEVOPS/pages/1694236886/Terraform+Runner+Quickstart).
+- If you encounter any issues or have questions, reach out to the team on the **#platform** slack channel.
+
+### Vault Configuration Updates
+- Any secrets required for this service will be stored in Vault. For any updates to the Vault configuration, please consult with the **#platform** team and submit a workflow request.
+
+### Useful Links
+- [ECS service config dev repository](https://github.com/companieshouse/ecs-service-configs-dev)
+- [ECS service config production repository](https://github.com/companieshouse/ecs-service-configs-production)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
         <relativePath/>
     </parent>
 
@@ -22,6 +22,7 @@
         <maven.compiler.target>21</maven.compiler.target>
 
         <!-- external dependencies -->
+        <avro.version>1.12.0</avro.version>
         <docker-java-api.version>3.3.6</docker-java-api.version>
         <guava.version>33.2.1-jre</guava.version>
         <handlebars.version>4.4.0</handlebars.version>
@@ -31,13 +32,11 @@
         <jackson.version>2.17.1</jackson.version>
         <log4j-bom.version>2.22.1</log4j-bom.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-        <spring-boot-dependencies.version>3.2.6</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>3.3.4</spring-boot-dependencies.version>
         <spring-boot-maven-plugin.version>3.2.4</spring-boot-maven-plugin.version>
         <spring-cloud-contract-wiremock.version>4.1.3</spring-cloud-contract-wiremock.version>
         <spring-kafka-test.version>3.2.0</spring-kafka-test.version>
         <spring-retry.version>2.0.5</spring-retry.version>
-        <!--Overriding spring-web version to remove vulnerability-->
-        <spring-web.version>6.1.6</spring-web.version>
         <!-- system-rules: 1.17.2 is the latest version that works with JUnit 5.
              See https://github.com/stefanbirkner/system-rules/issues/70 -->
         <system-rules-version>1.17.2</system-rules-version>
@@ -82,12 +81,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <!--Overriding spring-web version to remove vulnerability-->
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>${spring-web.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
@@ -175,12 +168,31 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-webapp</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-fileupload</groupId>
+                    <artifactId>commons-fileupload</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>ch-kafka</artifactId>
             <version>${ch-kafka.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${avro.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.kafka</groupId>


### PR DESCRIPTION
item-group-workflow-api
adding ecs information to the README
and @foman-ch changes: companieshouse-parent to 2.1.6 and resolving vulnerabilities as we can't merge the README without these changes done due to security-checks job failing and blocking the PR from being merged.